### PR TITLE
Fix a little warning, due to write return value not tested

### DIFF
--- a/log.c
+++ b/log.c
@@ -190,7 +190,15 @@ void log_msg(char *file, char *function, int line, char l, char *s, ... )
 		if(!use_syslog) fprintf(stderr, "\033[%im", colour);
 	}
 	
-	if(!use_syslog) write(fd_log, o, strlen(o));
+        int anErr = 0;
+
+        if(!use_syslog)
+        {
+               anErr = write(fd_log, o, strlen(o));
+
+               if (anErr < 0)
+                       fprintf(stderr, "Pb with write()" );
+        }
 	else
 	{
 		int p = LOG_INFO;


### PR DESCRIPTION
Hello,

I was testing fswebcam, and I'd like to say you a big thank you for sharing your code. In return, there was a little warning at builtime (kernel == Linux 5.14 oem-c), and this PR is a try to shut it up (I hope I'm not too wrong)

Feel free to use or not the code under MIT license or whatever you want or to delete it if you are not interested.

On my side, I'll do some tests with your software and I'll provide you feeback, or some question if ever I'm stuck.
Thanks again :-)